### PR TITLE
Issue 2 import script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "eslint-plugin-import": "2.27.5",
         "sinon": "15.0.1",
         "stylelint": "15.2.0",
-        "stylelint-config-prettier": "9.0.5",
         "stylelint-config-standard": "30.0.1"
       }
     },
@@ -6284,22 +6283,6 @@
         "url": "https://opencollective.com/stylelint"
       }
     },
-    "node_modules/stylelint-config-prettier": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.5.tgz",
-      "integrity": "sha512-U44lELgLZhbAD/xy/vncZ2Pq8sh2TnpiPvo38Ifg9+zeioR+LAkHu0i6YORIOxFafZoVg0xqQwex6e6F25S5XA==",
-      "dev": true,
-      "bin": {
-        "stylelint-config-prettier": "bin/check.js",
-        "stylelint-config-prettier-check": "bin/check.js"
-      },
-      "engines": {
-        "node": ">= 12"
-      },
-      "peerDependencies": {
-        "stylelint": ">= 11.x < 15"
-      }
-    },
     "node_modules/stylelint-config-recommended": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-10.0.1.tgz",
@@ -11702,13 +11685,6 @@
           "dev": true
         }
       }
-    },
-    "stylelint-config-prettier": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.5.tgz",
-      "integrity": "sha512-U44lELgLZhbAD/xy/vncZ2Pq8sh2TnpiPvo38Ifg9+zeioR+LAkHu0i6YORIOxFafZoVg0xqQwex6e6F25S5XA==",
-      "dev": true,
-      "requires": {}
     },
     "stylelint-config-recommended": {
       "version": "10.0.1",

--- a/tools/importer/import.js
+++ b/tools/importer/import.js
@@ -17,20 +17,28 @@ const createMetadataBlock = (main, document) => {
   if (publishedDate) meta.PublishedDate = publishedDate.content;
 
   // Author
-  const author = document.querySelector('article main article header.article-header ul.article-header-list span[rel="sioc:has_creator"] a');
-  if (author) meta.Author = author.text;
-  author.parentElement.parentElement.parentElement.remove();
+  const articleHeader = document.querySelector('article main article header.article-header ul.article-header-list');
+  if (articleHeader) {
+    const author = articleHeader.querySelector('span[rel="sioc:has_creator"] a');
+    if (author) {
+      meta.Author = author.text;
+      articleHeader.remove();
+    }
+  }
 
   // Article Key metadata
-  const articleKeysList = document.querySelectorAll('article main article div.article-preface .article-key-list li');
-  if (articleKeysList) {
-    articleKeysList.forEach((li) => {
-      const tag = li.textContent.split(':');
-      const key = tag[0];
-      const val = tag[1];
-      if (tag) meta[key] = val;
-    });
-    articleKeysList[0].parentElement.parentElement.remove();
+  const articlePreface = document.querySelector('article main article div.article-preface');
+  if (articlePreface) {
+    const articleKeysList = articlePreface.querySelectorAll('.article-key-list li');
+    if (articleKeysList) {
+      articleKeysList.forEach((li) => {
+        const tag = li.textContent.split(':');
+        const key = tag[0];
+        const val = tag[1];
+        if (tag) meta[key] = val;
+      });
+      articlePreface.remove();
+    }
   }
 
   // find the <meta property="og:image"> element

--- a/tools/importer/import.js
+++ b/tools/importer/import.js
@@ -1,0 +1,94 @@
+/* eslint-disable no-undef */
+const createMetadataBlock = (main, document) => {
+  const meta = {};
+  // add the template
+  meta.Template = 'Article';
+
+  // find the Title, Description and Subtitle
+  const title = document.head.querySelector('meta[property="og:title"]');
+  if (title) meta.Title = title.content;
+  const subtitle = document.querySelector('article main article header.article-header h3.article-subtitle');
+  if (subtitle) meta.Subtitle = subtitle.innerHTML;
+  const desc = document.head.querySelector('meta[property="og:description"]');
+  if (desc) meta.Description = desc.content;
+
+  // Published date
+  const publishedDate = document.head.querySelector('meta[property="article:published_time"]');
+  if (publishedDate) meta.PublishedDate = publishedDate.content;
+
+  // Author
+  const author = document.querySelector('article main article header.article-header ul.article-header-list span[rel="sioc:has_creator"] a');
+  if (author) meta.Author = author.text;
+  author.parentElement.parentElement.parentElement.remove();
+
+  // Article Key metadata
+  const articleKeysList = document.querySelectorAll('article main article div.article-preface .article-key-list li');
+  if (articleKeysList) {
+    articleKeysList.forEach((li) => {
+      const tag = li.textContent.split(':');
+      const key = tag[0];
+      const val = tag[1];
+      if (tag) meta[key] = val;
+    });
+    articleKeysList[0].parentElement.parentElement.remove();
+  }
+
+  // find the <meta property="og:image"> element
+  // const img = document.querySelector('[property="og:image"]');
+  // if (img) {
+  //   // create an <img> element
+  //   const el = document.createElement('img');
+  //   el.src = img.content;
+  //   meta.Image = el;
+  // }
+
+  // helper to create the metadata block
+  const block = WebImporter.Blocks.getMetadataBlock(document, meta);
+
+  // append the block to the main element
+  main.append(block);
+
+  // returning the meta object might be usefull to other rules
+  return meta;
+};
+
+export default {
+  transform: ({
+    // eslint-disable-next-line no-unused-vars
+    document,
+    url,
+  }) => {
+    // Remove unnecessary parts of the content
+    const main = document.body;
+    const results = [];
+
+    // Remove other stuff that shows up in the page
+    const nav = main.querySelector('div.wrap nav');
+    if (nav) nav.remove();
+    const header = main.querySelector('div.wrap header');
+    if (header) header.remove();
+    const skipLinkWrapper = main.querySelector('p.skip-link__wrapper');
+    if (skipLinkWrapper) skipLinkWrapper.remove();
+    const mainAd = main.querySelector('article main .main-content .row div.tmsads');
+    if (mainAd && mainAd.parentElement) {
+      mainAd.parentElement.remove();
+    }
+    const rightNav = main.querySelector('article main .main-content .row aside');
+    if (rightNav) rightNav.remove();
+    // Remove all iframes
+    main.querySelectorAll('iframe').forEach((el) => el.remove());
+    // Remove Footer
+    const footer = main.querySelector('footer');
+    if (footer) footer.remove();
+
+    createMetadataBlock(main, document);
+
+    // main page import - "element" is provided, i.e. a docx will be created
+    results.push({
+      element: main,
+      path: new URL(url).pathname,
+    });
+
+    return results;
+  },
+};

--- a/tools/importer/import.js
+++ b/tools/importer/import.js
@@ -6,11 +6,21 @@ const createMetadataBlock = (main, document) => {
 
   // find the Title, Description and Subtitle
   const title = document.head.querySelector('meta[property="og:title"]');
-  if (title) meta.Title = title.content;
+  if (title) {
+    meta.Title = title.content;
+  } else {
+    const titleFromContent = document.querySelector('body article main article header h2.page-title');
+    if (titleFromContent) meta.Title = titleFromContent.textContent;
+  }
   const subtitle = document.querySelector('article main article header.article-header h3.article-subtitle');
   if (subtitle) meta.Subtitle = subtitle.innerHTML;
   const desc = document.head.querySelector('meta[property="og:description"]');
-  if (desc) meta.Description = desc.content;
+  if (desc) {
+    meta.Description = desc.content;
+  } else {
+    const description = document.head.querySelector('meta[name="description"]');
+    if (description) meta.Description = description.content;
+  }
 
   // Published date
   const publishedDate = document.head.querySelector('meta[property="article:published_time"]');


### PR DESCRIPTION
Updated import script to remove unnecessary fluff and keep the article content and pull out the metadata from the article and save it in the metadata table at the bottom.

No impact on pages yet. Just checking in the import script to tweak later. I am running an import right now with this version of the script.

Fix #2 

Test URLs:
- Before: https://main--channelco-iot--hlxsites.hlx.page/
- After: https://issue-2-import-script--channelco-iot--hlxsites.hlx.page/
