### PR TITLE
adding links for author and tags

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -83,14 +83,27 @@ function formatPublishedDate(rawDate) {
 function createHeaderList(publishedDate, author) {
   const headerList = document.createElement('div');
   headerList.classList.add('header-list');
-  headerList.innerHTML = `${publishedDate} / Author: ${author}`;
+  const trimmedAuthor = author.trim().toLowerCase().replace(' ', '-');
+  headerList.innerHTML = `${publishedDate} / Author: <a href="/authors/${trimmedAuthor}">${author}</a>`;
   return headerList;
 }
 
 function createListItem(key, value) {
   const listItem = document.createElement('li');
   listItem.classList.add('article-key-item');
-  listItem.textContent = `${capitalizeFirstLetter(key)}: ${value}`;
+  const values = value.split(',');
+  if (values.length > 1) {
+    listItem.innerHTML += `${capitalizeFirstLetter(key)}: `;
+    values.forEach((val, i) => {
+      const trimmedVal = val.trim();
+      listItem.innerHTML += `<a href="/${key}?id=${trimmedVal}" title="${trimmedVal}">${trimmedVal}</a>`;
+      if (i !== (values.length - 1)) {
+        listItem.innerHTML += ', ';
+      }
+    });
+  } else {
+    listItem.innerHTML = `${capitalizeFirstLetter(key)}: <a href="/${key}?id=${value.trim()}" title="">${value.trim()}</a>`;
+  }
   return listItem;
 }
 


### PR DESCRIPTION
Adding dynamic URLs to tags and author values that will go to specific tag and author pages with query parameters that have the value. Those pages will have newslist block that will be updated to pull the filter from query params

Fix #27 

Test URLs:
- Before: https://main--channelco-iot--hlxsites.hlx.page/verticals/hospitality/cooking-with-iot-in-commercial-kitchens
- After: https://issue-27-taglinks--channelco-iot--hlxsites.hlx.page/verticals/hospitality/cooking-with-iot-in-commercial-kitchens
